### PR TITLE
added access to CaDiCaL "reserve" function

### DIFF
--- a/src/ccadical.cpp
+++ b/src/ccadical.cpp
@@ -35,4 +35,9 @@ extern "C"
   {
     return ((Wrapper *)wrapper)->solver->limit(name, val);
   }
+
+  void ccadical_reserve(CCaDiCaL *wrapper, int min_max_var = 0)
+  {
+    ((Wrapper *)wrapper)->solver->reserve(min_max_var);
+  }
 }


### PR DESCRIPTION
Hi,

I required the access to the "reserve" method of CaDiCaL for a project.
Here is a PR if you are interested in the feature.

I may publish my project through crates.io in few weeks.
If a new version of the CaDiCaL crate would include the PR code that would help me keep my dependencies "clean" :)

Best regards,
Emmanuel.